### PR TITLE
add a property for controlling perf_event_paranoid

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -562,6 +562,11 @@ on property:sys.sysctl.extra_free_kbytes=*
 on property:sys.sysctl.tcp_def_init_rwnd=*
     write /proc/sys/net/ipv4/tcp_default_init_rwnd ${sys.sysctl.tcp_def_init_rwnd}
 
+on property:security.perf_harden=0
+    write /proc/sys/kernel/perf_event_paranoid 1
+
+on property:security.perf_harden=1
+    write /proc/sys/kernel/perf_event_paranoid 3
 
 ## Daemon processes to be run by init.
 ##


### PR DESCRIPTION
This adds a system property for controlling unprivileged access to
perf_event_paranoid. It depends on adding kernel support for
perf_event_paranoid=3 based on grsecurity's PERF_HARDEN feature to
completely disable unprivileged access to perf. A minimal port of this
feature is used in the vanilla Debian kernel by default.

It hides the non-hardened value as an implementation detail, since while
it is currently 1, it will probably become 2 in the future.

(Cherry picked from commit 2b22a66382db8a2fdf5ed7a685085a6d7d67cf12)

Bug: 29054680

Change-Id: I6e3ae3cf18d8c76df94f879c34fb6fde519b89a9
